### PR TITLE
fix AS_HELP_STRING

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -58,7 +58,7 @@ AC_SUBST(CAJA_LIBS)
 
 # image-converter extension
 AC_ARG_ENABLE([image-converter],
-        AS_HELP_STRING([--enable-image-convert], [Enable image-converter plugin]),
+        AS_HELP_STRING([--enable-image-converter], [Enable image-converter plugin]),
         [enable_image_converter=$enableval],
         [enable_image_converter=yes])
 


### PR DESCRIPTION
  --enable-gtk-doc        use gtk-doc to build documentation [[default=no]]
  --enable-gtk-doc-html   build documentation in html format [[default=yes]]
  --enable-gtk-doc-pdf    build documentation in pdf format [[default=no]]
  --enable-image-convert  Enable image-converter plugin
