### PR TITLE
open-terminal: fix bugs with non-standard ports

### DIFF
--- a/open-terminal/caja-open-terminal.c
+++ b/open-terminal/caja-open-terminal.c
@@ -197,7 +197,7 @@ parse_sftp_uri (GFile *file, char **host, guint *port, char **user,
 	s = strchr(h, ':');
 
 	if (s && (p == NULL || s < p)) {
-		h_end = s-1;
+		h_end = s;
 		*s = '\0';
 		s++;
 	} else {

--- a/open-terminal/caja-open-terminal.c
+++ b/open-terminal/caja-open-terminal.c
@@ -44,7 +44,6 @@
 #include <stdlib.h> /* for atoi */
 #include <sys/stat.h>
 
-#define SSH_DEFAULT_PORT 22
 #define COT_SCHEMA "org.mate.caja-open-terminal"
 #define COT_DESKTOP_KEY "desktop-opens-home-dir"
 #define CAJA_SCHEMA "org.mate.caja.preferences"
@@ -226,6 +225,7 @@ append_sftp_info (char **terminal_exec,
 	GFile *vfs_uri;
 	char *host_name, *path, *user_name;
 	char *user_host, *cmd, *quoted_cmd;
+	char *host_port_switch;
 	guint host_port;
 
 	g_assert (terminal_exec != NULL);
@@ -241,7 +241,9 @@ append_sftp_info (char **terminal_exec,
 	parse_sftp_uri (vfs_uri, &host_name, &host_port, &user_name, &path);
 
 	if (host_port == 0) {
-		host_port = SSH_DEFAULT_PORT;
+		host_port_switch = g_strdup ("");
+	} else {
+		host_port_switch = g_strdup_printf ("-p %d", host_port);
 	}
 
 	if (user_name != NULL) {
@@ -250,7 +252,7 @@ append_sftp_info (char **terminal_exec,
 		user_host = g_strdup (host_name);
 	}
 
-	cmd = g_strdup_printf ("ssh %s -p %d -t \"cd \'%s\' && $SHELL -l\"", user_host, host_port, path);
+	cmd = g_strdup_printf ("ssh %s %s -t \"cd \'%s\' && $SHELL -l\"", user_host, host_port_switch, path);
 	quoted_cmd = g_shell_quote (cmd);
 	g_free (cmd);
 
@@ -260,6 +262,7 @@ append_sftp_info (char **terminal_exec,
 
 	g_free (host_name);
 	g_free (user_name);
+	g_free (host_port_switch);
 	g_free (path);
 
 	g_free (quoted_cmd);


### PR DESCRIPTION
The first commit allows to correctly use non-standard ssh ports from ssh_config without having to use it in the uri. Before it would fail because then the default port 22 was passed to ssh.

The second commit fixes a bug in parse_sftp_uri which would cut the last character of the host when a port is explicitly given.

# How to reproduce 1
1. Have a host with ssh on a non-standard port, e.g. 1234
2. configure the port in ~/.ssh/config
> Host myhost
> Port 1234
3. open with caja: `sftp://user@myhost/`
4. right click -> open terminal

## current behavior
mate-terminal opens up and closes again after ssh can't connect. The commandline called is
> mate-terminal -e ssh user@myhost -p 22 -t "cd '/' && $SHELL -l"

## expected behavior
open-terminal should determine the correct port used by ssh or leave it to ssh to do this. Thus the commandline should be
> mate-terminal -e ssh user@myhost -t "cd '/' && $SHELL -l"

# How to reproduce 2
1. Have a host with ssh on a non-standard port, e.g. 1234
3. open with caja: `sftp://user@myhost:1234/`
4. right click -> open terminal

## current behavior
mate-terminal opens up and closes again after ssh can't connect. The commandline called is
> mate-terminal -e ssh user@myhos -p 1234 -t "cd '/' && $SHELL -l"

## expected behavior
open-terminal should use the complete host name. Thus the commandline should be
> mate-terminal -e ssh user@myhost -p 1234 -t "cd '/' && $SHELL -l"