### PR TITLE
Consistent capitalization of commands

### DIFF
--- a/open-terminal/caja-open-terminal.c
+++ b/open-terminal/caja-open-terminal.c
@@ -420,7 +420,7 @@ open_terminal_menu_item_new (TerminalFileInfo  terminal_file_info,
 	switch (terminal_file_info) {
 		case FILE_INFO_LOCAL:
 		case FILE_INFO_SFTP:
-			name = _("Open In _Terminal");
+			name = _("Open in _Terminal");
 			if (is_file_item) {
 				tooltip = _("Open the currently selected folder in a terminal");
 			} else {
@@ -433,7 +433,7 @@ open_terminal_menu_item_new (TerminalFileInfo  terminal_file_info,
 				name = _("Open _Terminal");
 				tooltip = _("Open a terminal");
 			} else {
-				name = _("Open In _Terminal");
+				name = _("Open in _Terminal");
 				tooltip = _("Open the currently open folder in a terminal");
 			}
 			break;

--- a/sendto/caja-nste.c
+++ b/sendto/caja-nste.c
@@ -75,12 +75,12 @@ caja_nste_get_file_items (CajaMenuProvider *provider,
 	if (one_item && 
 	    !caja_file_info_is_directory ((CajaFileInfo *)files->data)) {
 		item = caja_menu_item_new ("CajaNste::sendto",
-					       _("Send To..."),
+					       _("Send to..."),
 					       _("Send file by mail, instant message..."),
 					       "document-send");
 	} else {
 		item = caja_menu_item_new ("CajaNste::sendto",
-					       _("Send To..."),
+					       _("Send to..."),
 					       _("Send files by mail, instant message..."),
 					       "document-send");
 	}


### PR DESCRIPTION
Gnome, as well as MATE, follows the rule of not capitalizing prepositions in titles and commands.

Let's make "Sent **To**..." and "Open **In** Terminal" consistent with the rest of the system.

![cap](https://cloud.githubusercontent.com/assets/2237894/8027897/69a81818-0da1-11e5-9a82-0d05970e620f.png)