### PR TITLE
 Add tags column using xattr: user.xdg.tags

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -26,6 +26,10 @@ if ENABLE_WALLPAPER
 SUBDIRS += wallpaper
 endif
 
+if ENABLE_XATTR_TAGS
+SUBDIRS += xattr-tags
+endif
+
 EXTRA_DIST = \
 	autogen.sh \
 	intltool-extract.in \

--- a/configure.ac
+++ b/configure.ac
@@ -285,6 +285,14 @@ AC_ARG_ENABLE([wallpaper],
 
 AM_CONDITIONAL(ENABLE_WALLPAPER, test x"$enable_wallpaper" = "xyes")
 
+# xattr-tags extension
+AC_ARG_ENABLE([xattr-tags],
+        AS_HELP_STRING([--enable-xattr-tags], [Enable set as xattr tags plugin]),
+        [enable_xattr_tags=$enableval],
+        [enable_xattr_tags=yes])
+
+AM_CONDITIONAL(ENABLE_XATTR_TAGS, test x"$enable_xattr_tags" = "xyes")
+
 # Get caja extensions directory
 AC_ARG_WITH(cajadir,
     AS_HELP_STRING([--with-cajadir=DIR],[Installation path for Caja extension @<:@auto@:>@]),
@@ -327,6 +335,8 @@ AC_OUTPUT([
   share/Makefile
   wallpaper/libcaja-wallpaper.caja-extension.in
   wallpaper/Makefile
+  xattr-tags/libcaja-xattr-tags.caja-extension.in
+  xattr-tags/Makefile
   po/Makefile.in 
 ])
 
@@ -343,4 +353,5 @@ Plugins to be build:
         Share:                  $enable_share
         Gksu:                   $enable_gksu
         Wallpaper:              $enable_wallpaper
+        xattr Tags:             $enable_xattr_tags
 "

--- a/xattr-tags/Makefile.am
+++ b/xattr-tags/Makefile.am
@@ -1,0 +1,18 @@
+AM_CPPFLAGS = $(CAJA_CFLAGS)
+
+caja_extensiondir = $(CAJA_EXTENSION_DIR)
+caja_extension_LTLIBRARIES = libcaja-xattr-tags.la
+
+libcaja_xattr_tags_la_SOURCES = \
+	caja-xattr-tags-extension.c\
+	caja-xattr-tag-sextension.h
+
+libcaja_xattr_tags_la_LDFLAGS = -module -avoid-version
+libcaja_xattr_tags_la_LIBADD = $(CAJA_LIBS)
+
+extensiondir = $(datadir)/caja/extensions
+extension_in_files = libcaja-xattr-tags.caja-extension.in
+extension_DATA = $(extension_in_files:.caja-extension.in=.caja-extension)
+%.caja-extension: %.caja-extension.in $(INTLTOOL_MERGE) $(wildcard $(top_srcdir)/po/*.po) ; $(AM_V_GEN) LC_ALL=C $(INTLTOOL_MERGE) -d -u -c $(top_builddir)/po/.intltool-merge-cache $(top_srcdir)/po $< $@
+
+CLEANFILES = $(extension_DATA)

--- a/xattr-tags/caja-xattr-tags-extension.c
+++ b/xattr-tags/caja-xattr-tags-extension.c
@@ -1,0 +1,222 @@
+/*
+ *  Caja xattr tags extension
+ *
+ *  Copyright (C) 2016 Felipe Barriga Richards
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ *  Authors: Felipe Barriga Richards <spam@felipebarriga.cl>
+ */
+ 
+#include <config.h>
+#include <string.h>
+#include <gio/gio.h>
+#include <glib/gi18n-lib.h>
+#include <libcaja-extension/caja-file-info.h>
+#include <libcaja-extension/caja-info-provider.h>
+#include <libcaja-extension/caja-column-provider.h>
+#include "caja-xattr-tags-extension.h"
+
+#define XATTR_TAGS_NAME "Xattr::Tags"
+#define XATTR_TAGS_ATTRIBUTE "xattr_tags"
+
+#define G_FILE_ATTRIBUTE_XATTR_XDG_TAGS "xattr::xdg.tags"
+
+static GObjectClass *parent_class;
+
+typedef struct {
+    gboolean cancelled;
+    CajaInfoProvider *provider;
+    CajaFileInfo *file;
+    GClosure *update_complete;
+} CajaXattrTagsHandle;
+
+static gchar *caja_xattr_tags_get_xdg_tags(CajaFileInfo *file)
+{
+    gchar *tags = NULL, *uri;
+    GFile *location;
+    GFileInfo *info;
+
+    uri = caja_file_get_activation_uri (file);
+    location = g_file_new_for_uri (uri);
+    info = g_file_query_info (location,
+                              G_FILE_ATTRIBUTE_XATTR_XDG_TAGS,
+                              0,
+                              NULL,
+                              NULL);
+
+    if (info) {
+        if (g_file_info_has_attribute(info, G_FILE_ATTRIBUTE_XATTR_XDG_TAGS)) {
+            tags = g_strdup(g_file_info_get_attribute_string(info, G_FILE_ATTRIBUTE_XATTR_XDG_TAGS));
+        }
+        g_object_unref (info);
+    }
+    g_object_unref (location);
+    g_free (uri);
+
+    return tags;
+}
+
+static CajaOperationResult
+caja_xattr_tags_update_file_info(CajaInfoProvider *provider,
+                            CajaFileInfo *file,
+                            GClosure *update_complete,
+                            CajaOperationHandle **handle)
+{
+    gchar *value = caja_xattr_tags_get_xdg_tags(file);
+    if (value != NULL) {
+        caja_file_info_add_string_attribute(file, XATTR_TAGS_ATTRIBUTE, value);
+        g_free(value);
+    } else {
+        caja_file_info_add_string_attribute(file, XATTR_TAGS_ATTRIBUTE, "");
+    }
+    return CAJA_OPERATION_COMPLETE;
+}
+
+
+static void
+caja_xattr_tags_cancel_update(CajaInfoProvider *provider,
+                         CajaOperationHandle *handle)
+{
+    CajaXattrTagsHandle *xattr_handle;
+
+    xattr_handle = (CajaXattrTagsHandle*)handle;
+    xattr_handle->cancelled = TRUE;
+}
+
+static void
+caja_xattr_tags_info_provider_iface_init(CajaInfoProviderIface *iface)
+{
+    iface->update_file_info = caja_xattr_tags_update_file_info;
+    iface->cancel_update = caja_xattr_tags_cancel_update;
+}
+
+
+static GList *
+caja_xattr_tags_get_columns(CajaColumnProvider *provider)
+{
+    GList *ret = NULL;
+    CajaColumn *column = NULL;
+
+    column = caja_column_new(XATTR_TAGS_NAME,
+                             XATTR_TAGS_ATTRIBUTE,
+                             _("Tags"),
+                             _("Tags contained on xattrs"));
+    ret = g_list_append(NULL, column);
+
+    return ret;
+}
+
+static void
+caja_xattr_tags_column_provider_iface_init(CajaColumnProviderIface *iface)
+{
+    iface->get_columns = caja_xattr_tags_get_columns;
+}
+
+
+static void 
+caja_xattr_tags_instance_init(CajaXattrTags *cajaXattrTags)
+{
+}
+
+
+static void
+caja_xattr_tags_class_init(CajaXattrTagsClass *class)
+{
+    parent_class = g_type_class_peek_parent (class);
+}
+
+
+static GType caja_xattr_tags_type = 0;
+
+
+GType
+caja_xattr_tags_get_type(void)
+{
+    return caja_xattr_tags_type;
+}
+
+
+void
+caja_xattr_tags_register_type(GTypeModule *module)
+{
+    static const GTypeInfo info = {
+        sizeof (CajaXattrTagsClass),
+        (GBaseInitFunc) NULL,
+        (GBaseFinalizeFunc) NULL,
+        (GClassInitFunc) caja_xattr_tags_class_init,
+        NULL, 
+        NULL,
+        sizeof (CajaXattrTags),
+        0,
+        (GInstanceInitFunc) caja_xattr_tags_instance_init,
+    };
+
+
+    caja_xattr_tags_type = g_type_module_register_type (module,
+                                            G_TYPE_OBJECT,
+                                            "CajaXattrTags",
+                                            &info, 0);
+
+    static const GInterfaceInfo info_provider_iface_info = {
+            (GInterfaceInitFunc) caja_xattr_tags_info_provider_iface_init,
+            NULL,
+            NULL
+    };
+
+    g_type_module_add_interface (module,
+                                 CAJA_TYPE_XATTR_TAGS,
+                                 CAJA_TYPE_INFO_PROVIDER,
+                                 &info_provider_iface_info);
+
+    static const GInterfaceInfo column_provider_iface_info = {
+            (GInterfaceInitFunc) caja_xattr_tags_column_provider_iface_init,
+            NULL,
+            NULL
+    };
+
+
+    g_type_module_add_interface (module,
+                                 CAJA_TYPE_XATTR_TAGS,
+                                 CAJA_TYPE_COLUMN_PROVIDER,
+                                 &column_provider_iface_info);
+
+}
+
+void
+caja_module_initialize (GTypeModule  *module)
+{
+    g_print ("Initializing caja-xattr-tags extension");
+
+    caja_xattr_tags_register_type (module);
+}
+
+void
+caja_module_shutdown (void)
+{
+}
+
+/* List all the extension types.  */
+void
+caja_module_list_types (const GType **types,
+                        int          *num_types)
+{
+    static GType type_list[1];
+
+    type_list[0] = CAJA_TYPE_XATTR_TAGS;
+
+    *types = type_list;
+    *num_types = 1;
+}

--- a/xattr-tags/caja-xattr-tags-extension.h
+++ b/xattr-tags/caja-xattr-tags-extension.h
@@ -1,0 +1,55 @@
+/*
+ *  Caja xattr tags extension
+ *
+ *  Copyright (C) 2016 Felipe Barriga Richards
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ *  Authors: Felipe Barriga Richards <spam@felipebarriga.cl>
+ */
+ 
+#ifndef CAJA_XATTR_TAGS_EXTENSION_H
+#define CAJA_XATTR_TAGS_EXTENSION_H
+
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+
+#define CAJA_TYPE_XATTR_TAGS  (caja_xattr_tags_get_type ())
+#define CAJA_XATTR_TAGS(o)    (G_TYPE_CHECK_INSTANCE_CAST ((o), CAJA_TYPE_XATTR_TAGS, cajaXattrTags))
+#define CAJA_IS_XATTR_TAGS(o) (G_TYPE_CHECK_INSTANCE_TYPE ((o), CAJA_TYPE_XATTR_TAGS))
+
+typedef struct _CajaXattrTags      CajaXattrTags;
+typedef struct _CajaXattrTagsClass CajaXattrTagsClass;
+
+struct _CajaXattrTags {
+	GObject __parent;
+};
+
+struct _CajaXattrTagsClass {
+	GObjectClass __parent;
+};
+
+GType caja_xattr_tags_get_type(void);
+void  caja_xattr_tags_register_type(GTypeModule *module);
+
+//////////////////////////////////////////////////////
+// hack: libcaja-private/caja-file.c
+char *caja_file_get_activation_uri(CajaFile *file);
+//////////////////////////////////////////////////////
+
+G_END_DECLS
+
+#endif /* CAJA_XATTR_TAGS_EXTENSION_H */

--- a/xattr-tags/libcaja-xattr-tags.caja-extension.in.in
+++ b/xattr-tags/libcaja-xattr-tags.caja-extension.in.in
@@ -1,0 +1,8 @@
+[Caja Extension]
+Icon=desktop
+_Name=xattr Tags
+_Description=See tags stored on xattrs
+Author=Felipe Barriga Richards
+Copyright=Copyright (C) 2016 Felipe Barriga Richards
+Version=@VERSION@
+Website=http://www.mate-desktop.org/


### PR DESCRIPTION
This PR replaces #23 (I accidentally remove the branch so the previous PR was closed).

This PR add the extension 'xattr-tags'.
The extension add a new column in the file list called 'Tags' and populated with tags stored in xattr -> user.xdg.tags.

![e9a1fcb8-a833-11e6-8757-84da0b97baa7](https://cloud.githubusercontent.com/assets/718207/22132177/398a12d0-de97-11e6-9086-99e3e6aa6d88.png)
