### PR TITLE
Change url project's website

### DIFF
--- a/gksu/libcaja-gksu.caja-extension.in.in
+++ b/gksu/libcaja-gksu.caja-extension.in.in
@@ -5,4 +5,4 @@ _Description=Privilege granting extension
 Author=Gustavo Noronha Silva
 Copyright=Copyright (C) 2002-2005 Gustavo Noronha Silva
 Version=@VERSION@
-Website=http://www.mate-desktop.org/
+Website=https://mate-desktop.org/

--- a/image-converter/libcaja-image-converter.caja-extension.in.in
+++ b/image-converter/libcaja-image-converter.caja-extension.in.in
@@ -5,4 +5,4 @@ _Description=Rotate and resize images
 Author=Jürg Billeter <j@bitron.ch>
 Copyright=Copyright (C) 2004-2005 Jürg Billeter
 Version=@VERSION@
-Website=http://www.mate-desktop.org/
+Website=https://mate-desktop.org/

--- a/open-terminal/libcaja-open-terminal.caja-extension.in.in
+++ b/open-terminal/libcaja-open-terminal.caja-extension.in.in
@@ -5,4 +5,4 @@ _Description=Open terminals from folders
 Author=Christian Neumair <chris@gnome-de.org>
 Copyright=Copyright (C) 2004, 2005 Free Software Foundation, Inc.
 Version=@VERSION@
-Website=http://www.mate-desktop.org/
+Website=https://mate-desktop.org/

--- a/sendto/libcaja-sendto.caja-extension.in.in
+++ b/sendto/libcaja-sendto.caja-extension.in.in
@@ -5,4 +5,4 @@ _Description=Integrates email clients and Pidgin
 Author=Roberto Majadas <roberto.majadas@openshine.com>
 Copyright=Copyright (C) 2004 Roberto Majadas
 Version=@VERSION@
-Website=http://www.mate-desktop.org/
+Website=https://mate-desktop.org/

--- a/share/libcaja-share.caja-extension.in.in
+++ b/share/libcaja-share.caja-extension.in.in
@@ -5,4 +5,4 @@ _Description=Allows to quickly share a folder
 Author=Sebastien Estienne <sebastien.estienne@gmail.com>
 Copyright=Copyright 2005 Ethium, Inc.
 Version=@VERSION@
-Website=http://www.mate-desktop.org/
+Website=https://mate-desktop.org/

--- a/wallpaper/libcaja-wallpaper.caja-extension.in.in
+++ b/wallpaper/libcaja-wallpaper.caja-extension.in.in
@@ -5,4 +5,4 @@ _Description=Allows to quickly set wallpaper
 Author=Stefano Karapetsas;Adam Israel
 Copyright=Copyright (C) 2014 Stefano Karapetsas
 Version=@VERSION@
-Website=http://www.mate-desktop.org/
+Website=https://mate-desktop.org/

--- a/xattr-tags/libcaja-xattr-tags.caja-extension.in.in
+++ b/xattr-tags/libcaja-xattr-tags.caja-extension.in.in
@@ -5,4 +5,4 @@ _Description=View tags stored in extended attributes
 Author=Felipe Barriga Richards
 Copyright=Copyright (C) 2016 Felipe Barriga Richards
 Version=@VERSION@
-Website=http://www.mate-desktop.org/
+Website=https://mate-desktop.org/


### PR DESCRIPTION
Now the official web site is https://mate-desktop.org/.