### PR TITLE
Build either with gupnp version 1.0 or 1.2.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -196,6 +196,8 @@ if test "x$enable_sendto" = "xyes"; then
             fi
             ;;
             upnp)
+                PKG_CHECK_MODULES(UPNP, gupnp-1.2 >= $GUPNP_REQUIRED,
+                    enable_upnp=yes AC_DEFINE([HAS_GUPNP_VERSION_1_2], 1, ["Version is at least 1.2"]), enable_upnp=no)
                 PKG_CHECK_MODULES(UPNP, gupnp-1.0 >= $GUPNP_REQUIRED,
                     enable_upnp=yes, enable_upnp=no)
                 if test "${enable_upnp}" != "yes" ; then

--- a/sendto/plugins/upnp/upnp.c
+++ b/sendto/plugins/upnp/upnp.c
@@ -206,7 +206,11 @@ init (NstPlugin *plugin)
 		return FALSE;
 	g_free (upload_cmd);
 
+#ifdef HAS_GUPNP_VERSION_1_2
+	context_manager = gupnp_context_manager_create (0);
+#else
 	context_manager = gupnp_context_manager_new (NULL, 0);
+#endif
 	g_assert (context_manager != NULL);
 	g_signal_connect (context_manager, "context-available",
 			  G_CALLBACK (on_context_available), NULL);


### PR DESCRIPTION
This fixes https://github.com/mate-desktop/caja-extensions/issues/52.

* (configure.ac): Check also for gupnp-1.2 and set HAS_GUPNP_VERSION_1_2
to yes if found.
* (sendto/plugins/upnp/upnp.c): Use gupnp_context_manager_create when
building with gupnp-1.2 as gupnp_context_manager_new was removed.

Not sure if the configure.ac part is okay so. I'm open for improvements :P

I build caja-extensions with gupnp 1.0 and 1.2 and it worked fine. They both link against the correct library version and doesn't fail to build in `upnp.c` anymore :)