### PR TITLE
sendto: value stored to 'file' is never read

### DIFF
--- a/sendto/caja-nste.c
+++ b/sendto/caja-nste.c
@@ -37,12 +37,10 @@ sendto_callback (CajaMenuItem *item,
 	      gpointer          user_data)
 {
 	GList            *files, *scan;
-	CajaFileInfo *file;
 	gchar            *uri;
 	GString          *cmd;
 
 	files = g_object_get_data (G_OBJECT (item), "files");
-	file = files->data;
 
 	cmd = g_string_new ("caja-sendto");
 


### PR DESCRIPTION
Dead storage reported by Clang analyzer