### PR TITLE
share: rewrite share-dialog.ui from scratch

### DIFF
--- a/share/caja-share.c
+++ b/share/caja-share.c
@@ -68,8 +68,7 @@ typedef struct {
   GtkWidget *main; /* Widget that holds all the rest.  Its "PropertyPage" GObject-data points to this PropertyPage structure */
 
   GtkWidget *checkbutton_share_folder;
-  GtkWidget *hbox_share_name;
-  GtkWidget *hbox_share_comment;
+  GtkWidget *box_share_content;
   GtkWidget *entry_share_name;
   GtkWidget *checkbutton_share_rw_ro;
   GtkWidget *checkbutton_share_guest_ok;
@@ -528,11 +527,7 @@ static void
 property_page_set_controls_sensitivity (PropertyPage *page,
 					gboolean      sensitive)
 {
-  gtk_widget_set_sensitive (page->entry_share_name, sensitive);
-  gtk_widget_set_sensitive (page->entry_share_comment, sensitive);
-  gtk_widget_set_sensitive (page->hbox_share_comment, sensitive);
-  gtk_widget_set_sensitive (page->hbox_share_name, sensitive);
-  gtk_widget_set_sensitive (page->checkbutton_share_rw_ro, sensitive);
+  gtk_widget_set_sensitive (page->box_share_content, sensitive);
 
   if (sensitive)
     {
@@ -712,8 +707,7 @@ create_property_page (CajaFileInfo *fileinfo)
 			  free_property_page_cb);
 
   page->checkbutton_share_folder = GTK_WIDGET (gtk_builder_get_object (page->ui,"checkbutton_share_folder"));
-  page->hbox_share_comment = GTK_WIDGET (gtk_builder_get_object (page->ui,"hbox_share_comment"));
-  page->hbox_share_name = GTK_WIDGET (gtk_builder_get_object (page->ui,"hbox_share_name"));
+  page->box_share_content = GTK_WIDGET (gtk_builder_get_object (page->ui,"box_share_content"));
   page->checkbutton_share_rw_ro = GTK_WIDGET (gtk_builder_get_object (page->ui,"checkbutton_share_rw_ro"));
   page->checkbutton_share_guest_ok = GTK_WIDGET (gtk_builder_get_object (page->ui,"checkbutton_share_guest_ok"));
   page->entry_share_name = GTK_WIDGET (gtk_builder_get_object (page->ui,"entry_share_name"));
@@ -724,8 +718,7 @@ create_property_page (CajaFileInfo *fileinfo)
 
   /* Sanity check so that we don't screw up the Glade file */
   g_assert (page->checkbutton_share_folder != NULL
-	    && page->hbox_share_comment != NULL
-	    && page->hbox_share_name != NULL
+	    && page->box_share_content != NULL
 	    && page->checkbutton_share_rw_ro != NULL
 	    && page->checkbutton_share_guest_ok != NULL
 	    && page->entry_share_name != NULL

--- a/share/share-dialog.ui
+++ b/share/share-dialog.ui
@@ -1,300 +1,284 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.1 -->
 <interface>
-  <!-- interface-requires gtk+ 2.12 -->
-  <!-- interface-naming-policy toplevel-contextual -->
-  <object class="GtkVBox" id="vbox1">
+  <requires lib="gtk+" version="3.22"/>
+  <object class="GtkImage" id="image1">
     <property name="visible">True</property>
-    <property name="border_width">12</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">process-stop</property>
+  </object>
+  <object class="GtkImage" id="image2">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">document-save</property>
+  </object>
+  <object class="GtkBox" id="vbox1">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="margin_left">12</property>
+    <property name="margin_right">12</property>
+    <property name="margin_top">12</property>
+    <property name="margin_bottom">12</property>
     <property name="orientation">vertical</property>
-    <property name="spacing">12</property>
+    <property name="spacing">8</property>
     <child>
-      <object class="GtkHBox" id="hbox6">
+      <object class="GtkBox">
         <property name="visible">True</property>
+        <property name="can_focus">False</property>
         <child>
-          <object class="GtkImage" id="logo_image">
+          <object class="GtkImage">
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="valign">start</property>
             <property name="pixel_size">64</property>
             <property name="icon_name">folder-remote</property>
+            <property name="icon_size">6</property>
           </object>
           <packing>
             <property name="expand">False</property>
+            <property name="fill">True</property>
             <property name="position">0</property>
           </packing>
         </child>
         <child>
-          <object class="GtkLabel" id="logo_label">
+          <object class="GtkLabel">
             <property name="visible">True</property>
-            <property name="label" translatable="yes">&lt;big&gt;&lt;b&gt;Folder Sharing&lt;/b&gt;&lt;/big&gt;</property>
-            <property name="use_markup">True</property>
-            <property name="justify">center</property>
+            <property name="can_focus">False</property>
+            <property name="halign">center</property>
+            <property name="label" translatable="yes">Folder Sharing</property>
+            <attributes>
+              <attribute name="weight" value="heavy"/>
+            </attributes>
           </object>
           <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
             <property name="position">1</property>
           </packing>
         </child>
       </object>
       <packing>
         <property name="expand">False</property>
+        <property name="fill">True</property>
         <property name="position">0</property>
       </packing>
     </child>
     <child>
-      <object class="GtkHSeparator" id="hseparator1">
+      <object class="GtkSeparator">
         <property name="visible">True</property>
+        <property name="can_focus">False</property>
       </object>
       <packing>
         <property name="expand">False</property>
+        <property name="fill">True</property>
         <property name="position">1</property>
       </packing>
     </child>
     <child>
-      <object class="GtkTable" id="table1">
+      <object class="GtkBox">
         <property name="visible">True</property>
-        <property name="n_rows">5</property>
-        <property name="n_columns">2</property>
-        <property name="column_spacing">12</property>
-        <property name="row_spacing">6</property>
-        <child>
-          <object class="GtkHBox" id="hbox_share_name">
-            <property name="visible">True</property>
-            <child>
-              <object class="GtkLabel" id="label1">
-                <property name="width_request">20</property>
-                <property name="visible">True</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="label_share_name">
-                <property name="visible">True</property>
-                <property name="xalign">0</property>
-                <property name="label" translatable="yes">Share _name:</property>
-                <property name="use_underline">True</property>
-                <property name="mnemonic_widget">entry_share_name</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="top_attach">1</property>
-            <property name="bottom_attach">2</property>
-            <property name="x_options">GTK_FILL</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkEntry" id="entry_share_name">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="invisible_char">&#x25CF;</property>
-          </object>
-          <packing>
-            <property name="left_attach">1</property>
-            <property name="right_attach">2</property>
-            <property name="top_attach">1</property>
-            <property name="bottom_attach">2</property>
-            <property name="y_options"></property>
-          </packing>
-        </child>
+        <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">8</property>
         <child>
           <object class="GtkCheckButton" id="checkbutton_share_folder">
             <property name="label" translatable="yes">Share this _folder</property>
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">False</property>
+            <property name="halign">start</property>
             <property name="use_underline">True</property>
             <property name="draw_indicator">True</property>
           </object>
           <packing>
-            <property name="right_attach">2</property>
-            <property name="x_options">GTK_FILL</property>
-            <property name="y_options"></property>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
           </packing>
         </child>
         <child>
-          <object class="GtkHBox" id="hbox_share_comment">
+          <object class="GtkBox" id="box_share_content">
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="margin_left">12</property>
+            <property name="orientation">vertical</property>
+            <property name="spacing">8</property>
             <child>
-              <object class="GtkLabel" id="label2">
-                <property name="width_request">20</property>
+              <object class="GtkGrid">
                 <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="margin_top">8</property>
+                <property name="margin_bottom">8</property>
+                <property name="row_spacing">8</property>
+                <property name="column_spacing">8</property>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="label" translatable="yes">Share _name:</property>
+                    <property name="use_underline">True</property>
+                    <property name="mnemonic_widget">entry_share_name</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="label" translatable="yes">Co_mment:</property>
+                    <property name="use_underline">True</property>
+                    <property name="mnemonic_widget">entry_share_comment</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkEntry" id="entry_share_name">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="hexpand">True</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkEntry" id="entry_share_comment">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="hexpand">True</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">1</property>
+                  </packing>
+                </child>
               </object>
               <packing>
                 <property name="expand">False</property>
-                <property name="fill">False</property>
+                <property name="fill">True</property>
                 <property name="position">0</property>
               </packing>
             </child>
             <child>
-              <object class="GtkLabel" id="label_share_comment">
+              <object class="GtkCheckButton" id="checkbutton_share_rw_ro">
+                <property name="label" translatable="yes">_Allow others to create and delete files in this folder</property>
                 <property name="visible">True</property>
-                <property name="xalign">0</property>
-                <property name="label" translatable="yes">Co_mment:</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">False</property>
+                <property name="halign">start</property>
                 <property name="use_underline">True</property>
-                <property name="mnemonic_widget">entry_share_comment</property>
+                <property name="draw_indicator">True</property>
               </object>
               <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
                 <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkCheckButton" id="checkbutton_share_guest_ok">
+                <property name="label" translatable="yes">_Guest access (for people without a user account)</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">False</property>
+                <property name="halign">start</property>
+                <property name="use_underline">True</property>
+                <property name="draw_indicator">True</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
               </packing>
             </child>
           </object>
           <packing>
-            <property name="top_attach">2</property>
-            <property name="bottom_attach">3</property>
-            <property name="x_options">GTK_FILL</property>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
           </packing>
         </child>
         <child>
-          <object class="GtkEntry" id="entry_share_comment">
+          <object class="GtkLabel" id="label_status">
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="invisible_char">&#x25CF;</property>
+            <property name="can_focus">False</property>
           </object>
           <packing>
-            <property name="left_attach">1</property>
-            <property name="right_attach">2</property>
-            <property name="top_attach">2</property>
-            <property name="bottom_attach">3</property>
-            <property name="y_options"></property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkCheckButton" id="checkbutton_share_rw_ro">
-            <property name="label" translatable="yes">_Allow others to create and delete files in this folder</property>
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">False</property>
-            <property name="use_underline">True</property>
-            <property name="draw_indicator">True</property>
-          </object>
-          <packing>
-            <property name="right_attach">2</property>
-            <property name="top_attach">3</property>
-            <property name="bottom_attach">4</property>
-            <property name="x_options">GTK_FILL</property>
-            <property name="y_options"></property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkCheckButton" id="checkbutton_share_guest_ok">
-            <property name="label" translatable="yes">_Guest access (for people without a user account)</property>
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">False</property>
-            <property name="use_underline">True</property>
-            <property name="draw_indicator">True</property>
-          </object>
-          <packing>
-            <property name="right_attach">2</property>
-            <property name="top_attach">4</property>
-            <property name="bottom_attach">5</property>
-            <property name="x_options">GTK_FILL</property>
-            <property name="y_options"></property>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
           </packing>
         </child>
       </object>
       <packing>
         <property name="expand">False</property>
+        <property name="fill">True</property>
         <property name="position">2</property>
       </packing>
     </child>
     <child>
-      <object class="GtkLabel" id="label_status">
+      <object class="GtkSeparator">
         <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="wrap">True</property>
-        <property name="selectable">True</property>
+        <property name="can_focus">False</property>
       </object>
       <packing>
         <property name="expand">False</property>
+        <property name="fill">True</property>
         <property name="position">3</property>
       </packing>
     </child>
     <child>
-      <object class="GtkHSeparator" id="hseparator2"/>
-      <packing>
-        <property name="expand">False</property>
-        <property name="position">4</property>
-      </packing>
-    </child>
-    <child>
-      <object class="GtkScrolledWindow" id="scrolledwindow1">
-        <property name="sensitive">False</property>
-        <property name="can_focus">True</property>
-        <property name="hscrollbar_policy">automatic</property>
-        <property name="vscrollbar_policy">automatic</property>
-        <property name="shadow_type">in</property>
-        <child>
-          <object class="GtkTreeView" id="treeview_share_list">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-          </object>
-        </child>
-      </object>
-      <packing>
-        <property name="padding">1</property>
-        <property name="position">5</property>
-      </packing>
-    </child>
-    <child>
-      <object class="GtkHSeparator" id="hseparator3">
-        <property name="sensitive">False</property>
-      </object>
-      <packing>
-        <property name="expand">False</property>
-        <property name="position">6</property>
-      </packing>
-    </child>
-    <child>
-      <object class="GtkHButtonBox" id="hbuttonbox1">
+      <object class="GtkButtonBox">
         <property name="visible">True</property>
-        <property name="spacing">5</property>
-        <property name="layout_style">end</property>
+        <property name="can_focus">False</property>
+        <property name="halign">end</property>
+        <property name="valign">end</property>
+        <property name="spacing">8</property>
+        <property name="layout_style">start</property>
         <child>
           <object class="GtkButton" id="button_cancel">
-            <property name="label">gtk-cancel</property>
+            <property name="label" translatable="yes">_Cancel</property>
             <property name="visible">True</property>
             <property name="can_focus">True</property>
-            <property name="can_default">True</property>
             <property name="receives_default">True</property>
-            <property name="use_stock">True</property>
+            <property name="image">image1</property>
+            <property name="use_underline">True</property>
           </object>
           <packing>
-            <property name="expand">False</property>
-            <property name="fill">False</property>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
             <property name="position">0</property>
           </packing>
         </child>
         <child>
           <object class="GtkButton" id="button_apply">
+            <property name="label" translatable="yes">_Save</property>
             <property name="visible">True</property>
             <property name="can_focus">True</property>
-            <property name="can_default">True</property>
             <property name="receives_default">True</property>
-            <child>
-              <object class="GtkImage" id="image1">
-                <property name="visible">True</property>
-                <property name="stock">gtk-save</property>
-              </object>
-            </child>
+            <property name="image">image2</property>
+            <property name="use_underline">True</property>
           </object>
           <packing>
-            <property name="expand">False</property>
-            <property name="fill">False</property>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
             <property name="position">1</property>
           </packing>
         </child>
       </object>
       <packing>
         <property name="expand">False</property>
-        <property name="position">7</property>
+        <property name="fill">True</property>
+        <property name="position">4</property>
       </packing>
     </child>
   </object>


### PR DESCRIPTION
Test:
- Enable Samba usershare. There is a good stating guide at https://wiki.archlinux.org/index.php/Samba#Enable_Usershares.
- Share a folder using caja:
Right click on a folder and select Properties item.
![Screenshot at 2020-03-04 13-30-17](https://user-images.githubusercontent.com/10171411/75879823-5cf6e100-5e1c-11ea-8983-0a954b477ff8.png)
Right click on a folder and select Sharing Options item.
![Screenshot at 2020-03-04 14-02-55](https://user-images.githubusercontent.com/10171411/75882175-ed372500-5e20-11ea-8665-689c2b4e3b86.png)
- Show netshare:
```
$ net usershare info --long
[Públic]
path=/home/robert/Públic
comment=
usershare_acl=Everyone:F,
guest_ok=y
```
- Access to usershare:

![Screenshot at 2020-03-04 13-34-24](https://user-images.githubusercontent.com/10171411/75880141-0211b980-5e1d-11ea-9d52-094c978a4a2d.png)
