### PR TITLE
Do not collect the translation for Icon

### DIFF
--- a/gksu/Makefile.am
+++ b/gksu/Makefile.am
@@ -31,6 +31,6 @@ extensiondir = $(datadir)/caja/extensions
 extension_in_files = libcaja-gksu.caja-extension.desktop.in
 extension_DATA = $(extension_in_files:.caja-extension.desktop.in=.caja-extension)
 $(extension_DATA): $(extension_in_files)
-	$(AM_V_GEN) $(MSGFMT) --desktop --keyword=Copyright --keyword=Name --keyword=Description --template $< -d $(top_srcdir)/po -o $@
+	$(AM_V_GEN) $(MSGFMT) --desktop --keyword= --keyword=Copyright --keyword=Name --keyword=Description --template $< -d $(top_srcdir)/po -o $@
 
 CLEANFILES = $(extension_DATA)

--- a/image-converter/Makefile.am
+++ b/image-converter/Makefile.am
@@ -48,7 +48,7 @@ extensiondir = $(datadir)/caja/extensions
 extension_in_files = libcaja-image-converter.caja-extension.desktop.in
 extension_DATA = $(extension_in_files:.caja-extension.desktop.in=.caja-extension)
 $(extension_DATA): $(extension_in_files)
-	$(AM_V_GEN) $(MSGFMT) --desktop --keyword=Copyright --keyword=Name --keyword=Description --template $< -d $(top_srcdir)/po -o $@
+	$(AM_V_GEN) $(MSGFMT) --desktop --keyword= --keyword=Copyright --keyword=Name --keyword=Description --template $< -d $(top_srcdir)/po -o $@
 
 EXTRA_DIST = $(builder_DATA)
 

--- a/open-terminal/Makefile.am
+++ b/open-terminal/Makefile.am
@@ -40,7 +40,7 @@ extensiondir = $(datadir)/caja/extensions
 extension_in_files = libcaja-open-terminal.caja-extension.desktop.in
 extension_DATA = $(extension_in_files:.caja-extension.desktop.in=.caja-extension)
 $(extension_DATA): $(extension_in_files)
-	$(AM_V_GEN) $(MSGFMT) --desktop --keyword=Copyright --keyword=Name --keyword=Description --template $< -d $(top_srcdir)/po -o $@
+	$(AM_V_GEN) $(MSGFMT) --desktop --keyword= --keyword=Copyright --keyword=Name --keyword=Description --template $< -d $(top_srcdir)/po -o $@
 
 DISTCLEANFILES = \
 	org.mate.caja-open-terminal.gschema.xml

--- a/sendto/Makefile.am
+++ b/sendto/Makefile.am
@@ -83,7 +83,7 @@ extensiondir = $(datadir)/caja/extensions
 extension_in_files = libcaja-sendto.caja-extension.desktop.in
 extension_DATA = $(extension_in_files:.caja-extension.desktop.in=.caja-extension)
 $(extension_DATA): $(extension_in_files)
-	$(AM_V_GEN) $(MSGFMT) --desktop --keyword=Copyright --keyword=Name --keyword=Description --template $< -d $(top_srcdir)/po -o $@
+	$(AM_V_GEN) $(MSGFMT) --desktop --keyword= --keyword=Copyright --keyword=Name --keyword=Description --template $< -d $(top_srcdir)/po -o $@
 
 EXTRA_DIST = \
 	$(man_MANS) \

--- a/share/Makefile.am
+++ b/share/Makefile.am
@@ -41,7 +41,7 @@ extensiondir = $(datadir)/caja/extensions
 extension_in_files = libcaja-share.caja-extension.desktop.in
 extension_DATA = $(extension_in_files:.caja-extension.desktop.in=.caja-extension)
 $(extension_DATA): $(extension_in_files)
-	$(AM_V_GEN) $(MSGFMT) --desktop --keyword=Copyright --keyword=Name --keyword=Description --template $< -d $(top_srcdir)/po -o $@
+	$(AM_V_GEN) $(MSGFMT) --desktop --keyword= --keyword=Copyright --keyword=Name --keyword=Description --template $< -d $(top_srcdir)/po -o $@
 
 EXTRA_DIST = share-dialog.ui
 

--- a/wallpaper/Makefile.am
+++ b/wallpaper/Makefile.am
@@ -33,6 +33,6 @@ extensiondir = $(datadir)/caja/extensions
 extension_in_files = libcaja-wallpaper.caja-extension.desktop.in
 extension_DATA = $(extension_in_files:.caja-extension.desktop.in=.caja-extension)
 $(extension_DATA): $(extension_in_files)
-	$(AM_V_GEN) $(MSGFMT) --desktop --keyword=Copyright --keyword=Name --keyword=Description --template $< -d $(top_srcdir)/po -o $@
+	$(AM_V_GEN) $(MSGFMT) --desktop --keyword= --keyword=Copyright --keyword=Name --keyword=Description --template $< -d $(top_srcdir)/po -o $@
 
 CLEANFILES = $(extension_DATA)

--- a/xattr-tags/Makefile.am
+++ b/xattr-tags/Makefile.am
@@ -34,6 +34,6 @@ extensiondir = $(datadir)/caja/extensions
 extension_in_files = libcaja-xattr-tags.caja-extension.desktop.in
 extension_DATA = $(extension_in_files:.caja-extension.desktop.in=.caja-extension)
 $(extension_DATA): $(extension_in_files)
-	$(AM_V_GEN) $(MSGFMT) --desktop --keyword=Copyright --keyword=Name --keyword=Description --template $< -d $(top_srcdir)/po -o $@
+	$(AM_V_GEN) $(MSGFMT) --desktop --keyword= --keyword=Copyright --keyword=Name --keyword=Description --template $< -d $(top_srcdir)/po -o $@
 
 CLEANFILES = $(extension_DATA)


### PR DESCRIPTION
Icon names in desktop file was already translated, see https://github.com/mate-desktop/caja-extensions/commit/3795633754f4ed88bbdef720294a49fc3531f975
IHMO, we need to this in every repo where desktop files are used.