### PR TITLE
image-converter: Add error-dialog.ui

### DIFF
--- a/image-converter/Makefile.am
+++ b/image-converter/Makefile.am
@@ -52,6 +52,7 @@ $(extension_DATA): $(extension_in_files)
 EXTRA_DIST =						\
 	caja-image-resize.ui				\
 	caja-image-rotate.ui				\
+	error-dialog.ui					\
 	org.mate.caja.extensions.imageconverter.gresource.xml \
 	$(NULL)
 

--- a/image-converter/caja-image-resizer.c
+++ b/image-converter/caja-image-resizer.c
@@ -198,21 +198,24 @@ op_finished (GPid pid, gint status, gpointer data)
 
 	if (status != 0) {
 		/* resizing failed */
-		char *name = caja_file_info_get_name (file);
+		GtkBuilder *builder;
+		GtkWidget  *msg_dialog;
+		GObject    *dialog_text;
+		int         response_id;
+		char       *msg;
+		char       *name;
 
-		GtkWidget *msg_dialog = gtk_message_dialog_new (GTK_WINDOW (priv->progress_dialog),
-			GTK_DIALOG_DESTROY_WITH_PARENT, GTK_MESSAGE_ERROR,
-			GTK_BUTTONS_NONE,
-			"'%s' cannot be resized. Check whether you have permission to write to this folder.",
-			name);
-		g_free (name);
+		name  = caja_file_info_get_name (file);
 
-		gtk_dialog_add_button (GTK_DIALOG (msg_dialog), _("_Skip"), 1);
-		gtk_dialog_add_button (GTK_DIALOG (msg_dialog), GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL);
-		gtk_dialog_add_button (GTK_DIALOG (msg_dialog), _("_Retry"), 0);
-		gtk_dialog_set_default_response (GTK_DIALOG (msg_dialog), 0);
+		builder = gtk_builder_new_from_resource ("/org/mate/caja/extensions/imageconverter/error-dialog.ui");
+		msg_dialog = GTK_WIDGET (gtk_builder_get_object (builder, "error_dialog"));
+		dialog_text = gtk_builder_get_object (builder, "error_text");
+		msg = g_strdup_printf ("'%s' cannot be resized. Check whether you have permission to write to this folder.", name);
+		gtk_label_set_text (GTK_LABEL (dialog_text), msg);
+		g_free (msg);
+		g_object_unref (builder);
 
-		int response_id = gtk_dialog_run (GTK_DIALOG (msg_dialog));
+		response_id = gtk_dialog_run (GTK_DIALOG (msg_dialog));
 		gtk_widget_destroy (msg_dialog);
 		if (response_id == 0) {
 			retry = TRUE;

--- a/image-converter/caja-image-rotator.c
+++ b/image-converter/caja-image-rotator.c
@@ -195,21 +195,24 @@ op_finished (GPid pid, gint status, gpointer data)
 
 	if (status != 0) {
 		/* rotating failed */
-		char *name = caja_file_info_get_name (file);
+		GtkBuilder *builder;
+		GtkWidget  *msg_dialog;
+		GObject    *dialog_text;
+		int         response_id;
+		char       *msg;
+		char       *name;
 
-		GtkWidget *msg_dialog = gtk_message_dialog_new (GTK_WINDOW (priv->progress_dialog),
-			GTK_DIALOG_DESTROY_WITH_PARENT, GTK_MESSAGE_ERROR,
-			GTK_BUTTONS_NONE,
-			"'%s' cannot be rotated. Check whether you have permission to write to this folder.",
-			name);
-		g_free (name);
+		name  = caja_file_info_get_name (file);
 
-		gtk_dialog_add_button (GTK_DIALOG (msg_dialog), _("_Skip"), 1);
-		gtk_dialog_add_button (GTK_DIALOG (msg_dialog), GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL);
-		gtk_dialog_add_button (GTK_DIALOG (msg_dialog), _("_Retry"), 0);
-		gtk_dialog_set_default_response (GTK_DIALOG (msg_dialog), 0);
+		builder = gtk_builder_new_from_resource ("/org/mate/caja/extensions/imageconverter/error-dialog.ui");
+		msg_dialog = GTK_WIDGET (gtk_builder_get_object (builder, "error_dialog"));
+		dialog_text = gtk_builder_get_object (builder, "error_text");
+		msg = g_strdup_printf ("'%s' cannot be rotated. Check whether you have permission to write to this folder.", name);
+		gtk_label_set_text (GTK_LABEL (dialog_text), msg);
+		g_free (msg);
+		g_object_unref (builder);
 
-		int response_id = gtk_dialog_run (GTK_DIALOG (msg_dialog));
+		response_id = gtk_dialog_run (GTK_DIALOG (msg_dialog));
 		gtk_widget_destroy (msg_dialog);
 		if (response_id == 0) {
 			retry = TRUE;

--- a/image-converter/error-dialog.ui
+++ b/image-converter/error-dialog.ui
@@ -1,0 +1,147 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.2 -->
+<interface>
+  <requires lib="gtk+" version="3.22"/>
+  <object class="GtkImage" id="image1">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">process-stop</property>
+  </object>
+  <object class="GtkDialog" id="error_dialog">
+    <property name="can_focus">False</property>
+    <property name="border_width">12</property>
+    <property name="title" translatable="yes">Error</property>
+    <property name="window_position">center</property>
+    <property name="icon_name">dialog-error</property>
+    <property name="type_hint">dialog</property>
+    <child type="titlebar">
+      <placeholder/>
+    </child>
+    <child internal-child="vbox">
+      <object class="GtkBox">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
+        <child internal-child="action_area">
+          <object class="GtkButtonBox">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="hexpand">True</property>
+            <property name="homogeneous">True</property>
+            <property name="layout_style">expand</property>
+            <child>
+              <object class="GtkButton" id="button2">
+                <property name="label" translatable="yes">_Skip</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="use_underline">True</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="button1">
+                <property name="label" translatable="yes">_Cancel</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="image">image1</property>
+                <property name="use_underline">True</property>
+                <property name="always_show_image">True</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="button3">
+                <property name="label" translatable="yes">_Retry</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="use_underline">True</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+            <style>
+              <class name="linked"/>
+            </style>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="pack_type">end</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox" id="vbox8">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <child>
+              <object class="GtkBox" id="hbox3">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="spacing">12</property>
+                <child>
+                  <object class="GtkImage">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="icon_name">dialog-error</property>
+                    <property name="icon_size">6</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="error_text">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label" translatable="yes">An error has occurred.</property>
+                    <property name="wrap">True</property>
+                    <property name="selectable">True</property>
+                    <property name="max_width_chars">40</property>
+                    <property name="yalign">0</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+    <action-widgets>
+      <action-widget response="1">button2</action-widget>
+      <action-widget response="-6">button1</action-widget>
+      <action-widget response="0">button3</action-widget>
+    </action-widgets>
+  </object>
+</interface>

--- a/image-converter/org.mate.caja.extensions.imageconverter.gresource.xml
+++ b/image-converter/org.mate.caja.extensions.imageconverter.gresource.xml
@@ -19,5 +19,6 @@
   <gresource prefix="/org/mate/caja/extensions/imageconverter">
     <file compressed="true">caja-image-resize.ui</file>
     <file compressed="true">caja-image-rotate.ui</file>
+    <file compressed="true">error-dialog.ui</file>
   </gresource>
 </gresources>


### PR DESCRIPTION
Test: try converting an image from a folder without write access.

Before:

![Screenshot at 2020-03-17 12-53-30](https://user-images.githubusercontent.com/10171411/76853934-7f422300-684e-11ea-99d3-f1e3502f2ac9.png)

![Screenshot at 2020-03-17 12-53-55](https://user-images.githubusercontent.com/10171411/76853956-8701c780-684e-11ea-8532-cd8642b77bc8.png)


After:

![Screenshot at 2020-03-17 12-37-17](https://user-images.githubusercontent.com/10171411/76852846-7ea88d00-684c-11ea-993e-0c50396fab77.png)

![Screenshot at 2020-03-17 12-39-17](https://user-images.githubusercontent.com/10171411/76852852-823c1400-684c-11ea-94d4-373dc58e8265.png)
