### PR TITLE
Remove warning -Wshadow

### DIFF
--- a/sendto/caja-sendto-command.c
+++ b/sendto/caja-sendto-command.c
@@ -505,13 +505,13 @@ pack_entry_changed_cb (GObject *object, GParamSpec *spec, NS_ui *ui)
 }
 
 static void
-update_button_image (GtkSettings *settings,
-		     GParamSpec *spec,
-		     GtkWidget *widget)
+update_button_image (GtkSettings *gtk_settings,
+                     GParamSpec  *spec,
+                     GtkWidget   *widget)
 {
 	gboolean show_images;
 
-	g_object_get (settings, "gtk-button-images", &show_images, NULL);
+	g_object_get (gtk_settings, "gtk-button-images", &show_images, NULL);
 	if (show_images == FALSE)
 		gtk_widget_hide (widget);
 	else

--- a/sendto/plugins/pidgin/pidgin.c
+++ b/sendto/plugins/pidgin/pidgin.c
@@ -231,22 +231,21 @@ add_pidgin_contacts_to_model (GtkTreeStore *store,
 
 	g_hash_table_iter_init (&hiter, contact_hash);
 	while (g_hash_table_iter_next (&hiter, NULL, (gpointer)&contacts_group)) {
-		gint accounts;
+		gint num_accounts;
 
 		dat = g_ptr_array_index (contacts_group, 0);
 
-		accounts = contacts_group->len;
+		num_accounts = contacts_group->len;
 
 		gtk_tree_store_append (store, parent, NULL);
 		gtk_tree_store_set (store, parent, COL_ICON, NULL, COL_ALIAS, dat->alias, -1);
 
-		gint i;
-		for (i = 0; i < accounts; ++i) {
+		for (i = 0; i < num_accounts; ++i) {
 			dat = g_ptr_array_index (contacts_group, i);
 
 			icon = get_buddy_icon(dat->id);
 
-			if (accounts == 1) {
+			if (num_accounts == 1) {
 				g_value_init(&val, GDK_TYPE_PIXBUF);
 				g_value_set_object (&val, (gpointer)icon);
 				gtk_tree_store_set_value (store, parent, COL_ICON, &val);

--- a/sendto/plugins/upnp/upnp.c
+++ b/sendto/plugins/upnp/upnp.c
@@ -167,7 +167,7 @@ device_proxy_unavailable_cb (GUPnPControlPoint *cp,
 }
 
 static void
-on_context_available (GUPnPContextManager *context_manager,
+on_context_available (GUPnPContextManager *manager,
                       GUPnPContext        *context,
                       gpointer             user_data)
 {
@@ -187,7 +187,7 @@ on_context_available (GUPnPContextManager *context_manager,
 	gssdp_resource_browser_set_active (GSSDP_RESOURCE_BROWSER (cp), TRUE);
 
 	/* Let context manager take care of the control point life cycle */
-	gupnp_context_manager_manage_control_point (context_manager, cp);
+	gupnp_context_manager_manage_control_point (manager, cp);
 	g_object_unref (cp);
 }
 


### PR DESCRIPTION
```
caja-sendto-command.c:508:35: warning: declaration of 'settings' shadows a global declaration [-Wshadow]
  508 | update_button_image (GtkSettings *settings,
      |                      ~~~~~~~~~~~~~^~~~~~~~
--
pidgin.c:234:8: warning: declaration of 'accounts' shadows a previous local [-Wshadow]
  234 |   gint accounts;
      |        ^~~~~~~~
--
pidgin.c:243:8: warning: declaration of 'i' shadows a previous local [-Wshadow]
  243 |   gint i;
      |        ^
--
upnp.c:170:44: warning: declaration of 'context_manager' shadows a global declaration [-Wshadow]
  170 | on_context_available (GUPnPContextManager *context_manager,
      |                       ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~
```