### PR TITLE
Simplify the code for image converter operations

### DIFF
--- a/image-converter/caja-image-resizer.c
+++ b/image-converter/caja-image-resizer.c
@@ -295,12 +295,10 @@ run_op (CajaImageResizer *resizer)
 }
 
 static void
-caja_image_resizer_response_cb (GtkDialog *dialog,
-                                gint       response_id,
-                                gpointer   user_data)
+on_caja_image_resizer_response (GtkDialog        *dialog,
+                                gint              response_id,
+                                CajaImageResizer *resizer)
 {
-	CajaImageResizer *resizer = CAJA_IMAGE_RESIZER (user_data);
-
 	if (response_id == GTK_RESPONSE_OK) {
 		if (gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (resizer->append_radiobutton))) {
 			if (strlen (gtk_entry_get_text (resizer->name_entry)) == 0) {
@@ -362,7 +360,7 @@ caja_image_resizer_init (CajaImageResizer *resizer)
 
 	/* Connect signal */
 	g_signal_connect (resizer->resize_dialog, "response",
-	                  G_CALLBACK (caja_image_resizer_response_cb),
+	                  G_CALLBACK (on_caja_image_resizer_response),
 	                  resizer);
 
 	g_object_unref (builder);

--- a/image-converter/caja-image-resizer.c
+++ b/image-converter/caja-image-resizer.c
@@ -337,16 +337,9 @@ static void
 caja_image_resizer_init (CajaImageResizer *resizer)
 {
 	GtkBuilder *builder;
-	GError     *err = NULL;
 
-	builder = gtk_builder_new ();
+	builder = gtk_builder_new_from_resource ("/org/mate/caja/extensions/imageconverter/caja-image-resize.ui");
 	gtk_builder_set_translation_domain (builder, GETTEXT_PACKAGE);
-	/* If we're unable to load the xml file */
-	if (gtk_builder_add_from_resource (builder, "/org/mate/caja/extensions/imageconverter/caja-image-resize.ui", &err) == 0) {
-		g_warning ("%s", err->message);
-		g_error_free (err);
-		return;
-	}
 
 	/* Grab some widgets */
 	resizer->resize_dialog = GTK_DIALOG (gtk_builder_get_object (builder, "resize_dialog"));

--- a/image-converter/caja-image-resizer.h
+++ b/image-converter/caja-image-resizer.h
@@ -21,36 +21,19 @@
  *
  */
 
-#ifndef CAJA_IMAGE_RESIZER_H
-#define CAJA_IMAGE_RESIZER_H
+#ifndef __CAJA_IMAGE_RESIZER_H__
+#define __CAJA_IMAGE_RESIZER_H__
 
 #include <glib-object.h>
 
 G_BEGIN_DECLS
 
 #define CAJA_TYPE_IMAGE_RESIZER         (caja_image_resizer_get_type ())
-#define CAJA_IMAGE_RESIZER(o)           (G_TYPE_CHECK_INSTANCE_CAST ((o), CAJA_TYPE_IMAGE_RESIZER, CajaImageResizer))
-#define CAJA_IMAGE_RESIZER_CLASS(k)     (G_TYPE_CHECK_CLASS_CAST((k), CAJA_TYPE_IMAGE_RESIZER, CajaImageResizerClass))
-#define CAJA_IS_IMAGE_RESIZER(o)        (G_TYPE_CHECK_INSTANCE_TYPE ((o), CAJA_TYPE_IMAGE_RESIZER))
-#define CAJA_IS_IMAGE_RESIZER_CLASS(k)  (G_TYPE_CHECK_CLASS_TYPE ((k), CAJA_TYPE_IMAGE_RESIZER))
-#define CAJA_IMAGE_RESIZER_GET_CLASS(o) (G_TYPE_INSTANCE_GET_CLASS ((o), CAJA_TYPE_IMAGE_RESIZER, CajaImageResizerClass))
+G_DECLARE_FINAL_TYPE (CajaImageResizer, caja_image_resizer, CAJA, IMAGE_RESIZER, GObject)
 
-typedef struct _CajaImageResizer CajaImageResizer;
-typedef struct _CajaImageResizerClass CajaImageResizerClass;
-
-struct _CajaImageResizer {
-	GObject parent;
-};
-
-struct _CajaImageResizerClass {
-	GObjectClass parent_class;
-	/* Add Signal Functions Here */
-};
-
-GType caja_image_resizer_get_type (void);
 CajaImageResizer *caja_image_resizer_new (GList *files);
 void caja_image_resizer_show_dialog (CajaImageResizer *dialog);
 
 G_END_DECLS
 
-#endif /* CAJA_IMAGE_RESIZER_H */
+#endif /* __CAJA_IMAGE_RESIZER_H__ */

--- a/image-converter/caja-image-rotator.c
+++ b/image-converter/caja-image-rotator.c
@@ -290,10 +290,10 @@ run_op (CajaImageRotator *rotator)
 }
 
 static void
-caja_image_rotator_response_cb (GtkDialog *dialog, gint response_id, gpointer user_data)
+on_caja_image_rotator_response (GtkDialog        *dialog,
+                                gint              response_id,
+                                CajaImageRotator *rotator)
 {
-	CajaImageRotator *rotator = CAJA_IMAGE_ROTATOR (user_data);
-
 	if (response_id == GTK_RESPONSE_OK) {
 		if (gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (rotator->append_radiobutton))) {
 			if (strlen (gtk_entry_get_text (rotator->name_entry)) == 0) {
@@ -361,7 +361,7 @@ caja_image_rotator_init (CajaImageRotator *rotator)
 
 	/* Connect the signal */
 	g_signal_connect (rotator->rotate_dialog, "response",
-	                  G_CALLBACK (caja_image_rotator_response_cb),
+	                  G_CALLBACK (on_caja_image_rotator_response),
 			  rotator);
 
 	g_object_unref (builder);

--- a/image-converter/caja-image-rotator.c
+++ b/image-converter/caja-image-rotator.c
@@ -337,16 +337,9 @@ static void
 caja_image_rotator_init (CajaImageRotator *rotator)
 {
 	GtkBuilder *builder;
-	GError     *err = NULL;
 
-	builder = gtk_builder_new ();
+	builder = gtk_builder_new_from_resource ("/org/mate/caja/extensions/imageconverter/caja-image-rotate.ui");
 	gtk_builder_set_translation_domain (builder, GETTEXT_PACKAGE);
-	/* If we're unable to load the xml file */
-	if (gtk_builder_add_from_resource (builder, "/org/mate/caja/extensions/imageconverter/caja-image-rotate.ui", &err) == 0) {
-		g_warning ("%s", err->message);
-		g_error_free (err);
-		return;
-	}
 
 	/* Grab some widgets */
 	rotator->rotate_dialog = GTK_DIALOG (gtk_builder_get_object (builder, "rotate_dialog"));

--- a/image-converter/caja-image-rotator.h
+++ b/image-converter/caja-image-rotator.h
@@ -21,36 +21,19 @@
  *
  */
 
-#ifndef CAJA_IMAGE_ROTATOR_H
-#define CAJA_IMAGE_ROTATOR_H
+#ifndef __CAJA_IMAGE_ROTATOR_H__
+#define __CAJA_IMAGE_ROTATOR_H__
 
 #include <glib-object.h>
 
 G_BEGIN_DECLS
 
 #define CAJA_TYPE_IMAGE_ROTATOR         (caja_image_rotator_get_type ())
-#define CAJA_IMAGE_ROTATOR(o)           (G_TYPE_CHECK_INSTANCE_CAST ((o), CAJA_TYPE_IMAGE_ROTATOR, CajaImageRotator))
-#define CAJA_IMAGE_ROTATOR_CLASS(k)     (G_TYPE_CHECK_CLASS_CAST((k), CAJA_TYPE_IMAGE_ROTATOR, CajaImageRotatorClass))
-#define CAJA_IS_IMAGE_ROTATOR(o)        (G_TYPE_CHECK_INSTANCE_TYPE ((o), CAJA_TYPE_IMAGE_ROTATOR))
-#define CAJA_IS_IMAGE_ROTATOR_CLASS(k)  (G_TYPE_CHECK_CLASS_TYPE ((k), CAJA_TYPE_IMAGE_ROTATOR))
-#define CAJA_IMAGE_ROTATOR_GET_CLASS(o) (G_TYPE_INSTANCE_GET_CLASS ((o), CAJA_TYPE_IMAGE_ROTATOR, CajaImageRotatorClass))
+G_DECLARE_FINAL_TYPE (CajaImageRotator, caja_image_rotator, CAJA, IMAGE_ROTATOR, GObject)
 
-typedef struct _CajaImageRotator CajaImageRotator;
-typedef struct _CajaImageRotatorClass CajaImageRotatorClass;
-
-struct _CajaImageRotator {
-	GObject parent;
-};
-
-struct _CajaImageRotatorClass {
-	GObjectClass parent_class;
-	/* Add Signal Functions Here */
-};
-
-GType caja_image_rotator_get_type (void);
 CajaImageRotator *caja_image_rotator_new (GList *files);
 void caja_image_rotator_show_dialog (CajaImageRotator *dialog);
 
 G_END_DECLS
 
-#endif /* CAJA_IMAGE_ROTATOR_H */
+#endif /* __CAJA_IMAGE_ROTATOR_H__ */


### PR DESCRIPTION
It also removes the warnings below:
```
caja-image-rotator.c:337:41: warning: cast from function call of type 'gdouble' {aka 'double'} to non-matching type 'int' [-Wbad-function-cast]
  337 |    priv->angle = g_strdup_printf ("%d", (int) gtk_spin_button_get_value (priv->angle_spinbutton));
      |                                         ^
--
caja-image-resizer.c:326:42: warning: cast from function call of type 'gdouble' {aka 'double'} to non-matching type 'int' [-Wbad-function-cast]
  326 |    priv->size = g_strdup_printf ("%d%%", (int) gtk_spin_button_get_value (priv->pct_spinbutton));
      |                                          ^
caja-image-resizer.c:328:43: warning: cast from function call of type 'gdouble' {aka 'double'} to non-matching type 'int' [-Wbad-function-cast]
  328 |    priv->size = g_strdup_printf ("%dx%d", (int) gtk_spin_button_get_value (priv->width_spinbutton), (int) gtk_spin_button_get_value (priv->height_spinbutton));
      |                                           ^
caja-image-resizer.c:328:101: warning: cast from function call of type 'gdouble' {aka 'double'} to non-matching type 'int' [-Wbad-function-cast]
  328 |    priv->size = g_strdup_printf ("%dx%d", (int) gtk_spin_button_get_value (priv->width_spinbutton), (int) gtk_spin_button_get_value (priv->height_spinbutton));
      |                                                                                                     ^
```