### PR TITLE
build: allow users to disable gettext support (--disable-nls)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,10 @@
 ACLOCAL_AMFLAGS = -I m4 ${ACLOCAL_FLAGS}
 
-SUBDIRS = po
+SUBDIRS =
+
+if USE_NLS
+SUBDIRS += po
+endif
 
 if ENABLE_OPEN_TERMINAL
 SUBDIRS += open-terminal

--- a/configure.ac
+++ b/configure.ac
@@ -325,12 +325,13 @@ AC_MSG_NOTICE([Installing caja plugins in ${ac_with_cajadir}])
 AC_SUBST([CAJA_EXTENSION_DIR],[${ac_with_cajadir}])
 
 # gettext
-AM_GNU_GETTEXT_VERSION([0.19.8])
-AM_GNU_GETTEXT([external])
-
 GETTEXT_PACKAGE=AC_PACKAGE_NAME
 AC_SUBST(GETTEXT_PACKAGE)
 AC_DEFINE_UNQUOTED(GETTEXT_PACKAGE, "$GETTEXT_PACKAGE", [gettext package])
+
+AM_GNU_GETTEXT([external])
+AM_GNU_GETTEXT_VERSION([0.19.8])
+AM_CONDITIONAL([USE_NLS], [test "x${USE_NLS}" = "xyes"])
 
 DISABLE_DEPRECATED_CPPFLAGS="-DG_DISABLE_DEPRECATED -DGDK_PIXBUF_DISABLE_DEPRECATED"
 AC_SUBST(DISABLE_DEPRECATED_CPPFLAGS)
@@ -367,20 +368,24 @@ AC_OUTPUT([
 ])
 
 echo "
-      caja-extensions $VERSION
-      `echo caja-extensions $VERSION | sed "s/./=/g"`
-      prefix:                 ${prefix}
-      compiler:               ${CC}
-      cflags:                 ${CFLAGS}
-      warning flags:          ${WARN_CFLAGS}
-      caja-extension dir      ${ac_with_cajadir}
+Configure summary:
 
-      Plugins to be built:
-      Image Converter:        $enable_image_converter
-      Open Terminal:          $enable_open_terminal
-      Sendto:                 $enable_sendto
-      Share:                  $enable_share
-      Gksu:                   $enable_gksu
-      Wallpaper:              $enable_wallpaper
-      xattr Tags:             $enable_xattr_tags
+      ${PACKAGE_STRING}
+      `echo $PACKAGE_STRING | sed "s/./=/g"`
+      prefix:                     ${prefix}
+      compiler:                   ${CC}
+      cflags:                     ${CFLAGS}
+      warning flags:              ${WARN_CFLAGS}
+      caja-extension dir:         ${ac_with_cajadir}
+      Native Language support:    ${USE_NLS}
+
+      Plugins to be built
+      `echo "Plugins to be built" | sed "s/./=/g"`
+      Image Converter:            $enable_image_converter
+      Open Terminal:              $enable_open_terminal
+      Sendto:                     $enable_sendto
+      Share:                      $enable_share
+      Gksu:                       $enable_gksu
+      Wallpaper:                  $enable_wallpaper
+      xattr Tags:                 $enable_xattr_tags
 "

--- a/gksu/Makefile.am
+++ b/gksu/Makefile.am
@@ -31,7 +31,11 @@ extensiondir = $(datadir)/caja/extensions
 extension_in_files = libcaja-gksu.caja-extension.desktop.in
 extension_DATA = $(extension_in_files:.caja-extension.desktop.in=.caja-extension)
 $(extension_DATA): $(extension_in_files)
+if USE_NLS
 	$(AM_V_GEN) $(MSGFMT) --desktop --keyword= --keyword=Copyright --keyword=Name --keyword=Description --template $< -d $(top_srcdir)/po -o $@
+else
+	$(AM_V_GEN) cp $< $@
+endif
 
 CLEANFILES = $(extension_DATA)
 

--- a/image-converter/Makefile.am
+++ b/image-converter/Makefile.am
@@ -47,7 +47,11 @@ extensiondir = $(datadir)/caja/extensions
 extension_in_files = libcaja-image-converter.caja-extension.desktop.in
 extension_DATA = $(extension_in_files:.caja-extension.desktop.in=.caja-extension)
 $(extension_DATA): $(extension_in_files)
+if USE_NLS
 	$(AM_V_GEN) $(MSGFMT) --desktop --keyword= --keyword=Copyright --keyword=Name --keyword=Description --template $< -d $(top_srcdir)/po -o $@
+else
+	$(AM_V_GEN) cp $< $@
+endif
 
 EXTRA_DIST =						\
 	caja-image-resize.ui				\

--- a/image-converter/caja-image-resizer.c
+++ b/image-converter/caja-image-resizer.c
@@ -338,7 +338,9 @@ caja_image_resizer_init (CajaImageResizer *resizer)
 	GtkBuilder *builder;
 
 	builder = gtk_builder_new_from_resource ("/org/mate/caja/extensions/imageconverter/caja-image-resize.ui");
+#ifdef ENABLE_NLS
 	gtk_builder_set_translation_domain (builder, GETTEXT_PACKAGE);
+#endif /* ENABLE_NLS */
 
 	/* Grab some widgets */
 	resizer->resize_dialog = GTK_DIALOG (gtk_builder_get_object (builder, "resize_dialog"));

--- a/image-converter/caja-image-rotator.c
+++ b/image-converter/caja-image-rotator.c
@@ -340,7 +340,9 @@ caja_image_rotator_init (CajaImageRotator *rotator)
 	GtkBuilder *builder;
 
 	builder = gtk_builder_new_from_resource ("/org/mate/caja/extensions/imageconverter/caja-image-rotate.ui");
+#ifdef ENABLE_NLS
 	gtk_builder_set_translation_domain (builder, GETTEXT_PACKAGE);
+#endif /* ENABLE_NLS */
 
 	/* Grab some widgets */
 	rotator->rotate_dialog = GTK_DIALOG (gtk_builder_get_object (builder, "rotate_dialog"));

--- a/open-terminal/Makefile.am
+++ b/open-terminal/Makefile.am
@@ -40,7 +40,11 @@ extensiondir = $(datadir)/caja/extensions
 extension_in_files = libcaja-open-terminal.caja-extension.desktop.in
 extension_DATA = $(extension_in_files:.caja-extension.desktop.in=.caja-extension)
 $(extension_DATA): $(extension_in_files)
+if USE_NLS
 	$(AM_V_GEN) $(MSGFMT) --desktop --keyword= --keyword=Copyright --keyword=Name --keyword=Description --template $< -d $(top_srcdir)/po -o $@
+else
+	$(AM_V_GEN) cp $< $@
+endif
 
 DISTCLEANFILES = \
 	org.mate.caja-open-terminal.gschema.xml

--- a/sendto/Makefile.am
+++ b/sendto/Makefile.am
@@ -83,7 +83,11 @@ extensiondir = $(datadir)/caja/extensions
 extension_in_files = libcaja-sendto.caja-extension.desktop.in
 extension_DATA = $(extension_in_files:.caja-extension.desktop.in=.caja-extension)
 $(extension_DATA): $(extension_in_files)
+if USE_NLS
 	$(AM_V_GEN) $(MSGFMT) --desktop --keyword= --keyword=Copyright --keyword=Name --keyword=Description --template $< -d $(top_srcdir)/po -o $@
+else
+	$(AM_V_GEN) cp $< $@
+endif
 
 EXTRA_DIST = \
 	$(man_MANS) \

--- a/sendto/caja-sendto-command.c
+++ b/sendto/caja-sendto-command.c
@@ -445,9 +445,13 @@ set_model_for_options_combobox (NS_ui *ui)
 						   GTK_ICON_LOOKUP_USE_BUILTIN, NULL);
 		gtk_list_store_append (model, &iter);
 		gtk_list_store_set (model, &iter,
-					COLUMN_ICON, pixbuf,
-					COLUMN_DESCRIPTION, dgettext(p->info->gettext_package, p->info->description),
-					-1);
+		                    COLUMN_ICON, pixbuf,
+#ifdef ENABLE_NLS
+		                    COLUMN_DESCRIPTION, g_dgettext (p->info->gettext_package, p->info->description),
+#else
+		                    COLUMN_DESCRIPTION, p->info->description,
+#endif /* ENABLE_NLS */
+		                    -1);
 		if (last_used != NULL && !strcmp(last_used, p->info->id)) {
 			option = i;
 			last_used_support_dirs = (p->info->capabilities & CAJA_CAPS_SEND_DIRECTORIES);
@@ -799,9 +803,11 @@ int main (int argc, char **argv)
 	GOptionContext *context;
 	GError *error = NULL;
 
+#ifdef ENABLE_NLS
 	bindtextdomain (GETTEXT_PACKAGE, MATELOCALEDIR);
 	bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
 	textdomain (GETTEXT_PACKAGE);
+#endif /* ENABLE_NLS */
 
 	context = g_option_context_new ("");
 	g_option_context_add_main_entries (context, entries, GETTEXT_PACKAGE);

--- a/share/Makefile.am
+++ b/share/Makefile.am
@@ -41,7 +41,11 @@ extensiondir = $(datadir)/caja/extensions
 extension_in_files = libcaja-share.caja-extension.desktop.in
 extension_DATA = $(extension_in_files:.caja-extension.desktop.in=.caja-extension)
 $(extension_DATA): $(extension_in_files)
+if USE_NLS
 	$(AM_V_GEN) $(MSGFMT) --desktop --keyword= --keyword=Copyright --keyword=Name --keyword=Description --template $< -d $(top_srcdir)/po -o $@
+else
+	$(AM_V_GEN) cp $< $@
+endif
 
 EXTRA_DIST = share-dialog.ui
 

--- a/share/caja-share.c
+++ b/share/caja-share.c
@@ -694,7 +694,9 @@ create_property_page (CajaFileInfo *fileinfo)
 
 
   page->ui = gtk_builder_new ();
+#ifdef ENABLE_NLS
   gtk_builder_set_translation_domain (page->ui, GETTEXT_PACKAGE);
+#endif /* ENABLE_NLS */
   g_assert (gtk_builder_add_from_file (page->ui,
               INTERFACES_DIR"/share-dialog.ui", &error));
 

--- a/wallpaper/Makefile.am
+++ b/wallpaper/Makefile.am
@@ -33,7 +33,11 @@ extensiondir = $(datadir)/caja/extensions
 extension_in_files = libcaja-wallpaper.caja-extension.desktop.in
 extension_DATA = $(extension_in_files:.caja-extension.desktop.in=.caja-extension)
 $(extension_DATA): $(extension_in_files)
+if USE_NLS
 	$(AM_V_GEN) $(MSGFMT) --desktop --keyword= --keyword=Copyright --keyword=Name --keyword=Description --template $< -d $(top_srcdir)/po -o $@
+else
+	$(AM_V_GEN) cp $< $@
+endif
 
 CLEANFILES = $(extension_DATA)
 

--- a/xattr-tags/Makefile.am
+++ b/xattr-tags/Makefile.am
@@ -34,7 +34,11 @@ extensiondir = $(datadir)/caja/extensions
 extension_in_files = libcaja-xattr-tags.caja-extension.desktop.in
 extension_DATA = $(extension_in_files:.caja-extension.desktop.in=.caja-extension)
 $(extension_DATA): $(extension_in_files)
+if USE_NLS
 	$(AM_V_GEN) $(MSGFMT) --desktop --keyword= --keyword=Copyright --keyword=Name --keyword=Description --template $< -d $(top_srcdir)/po -o $@
+else
+	$(AM_V_GEN) cp $< $@
+endif
 
 CLEANFILES = $(extension_DATA)
 


### PR DESCRIPTION
### With NLS
```
$ find /usr/share/locale -type f -name 'caja-extensions.mo' -exec sudo rm -f {} +
$ ./autogen.sh --prefix=/usr && make && sudo make install
$ find /usr/share/locale -type f -name 'caja-extensions.mo' -exec du -ch {} + | grep total
932K	total
```
### Without NLS
```
$ find /usr/share/locale -type f -name 'caja-extensions.mo' -exec sudo rm -f {} +
$ ./autogen.sh --prefix=/usr --disable-nls && make && sudo make install
$ find /usr/share/locale -type f -name 'caja-extensions.mo' -exec du -ch {} + | grep total
```
