### PR TITLE
Fix build warnings about missing field initializer

### DIFF
--- a/gksu/libcaja-gksu.c
+++ b/gksu/libcaja-gksu.c
@@ -59,7 +59,8 @@ gksu_context_menu_register_type (GTypeModule *module)
 	NULL,
 	sizeof (GksuContextMenu),
 	0,
-	(GInstanceInitFunc) gksu_context_menu_init
+	(GInstanceInitFunc) gksu_context_menu_init,
+	NULL
     };
     static const GInterfaceInfo menu_provider_iface_info = {
 	(GInterfaceInitFunc)menu_provider_iface_init,

--- a/image-converter/caja-image-converter.c
+++ b/image-converter/caja-image-converter.c
@@ -182,6 +182,7 @@ caja_image_converter_register_type (GTypeModule *module)
 		sizeof (CajaImageConverter),
 		0,
 		(GInstanceInitFunc) caja_image_converter_instance_init,
+		NULL
 	};
 
 	static const GInterfaceInfo menu_provider_iface_info = {

--- a/open-terminal/caja-open-terminal.c
+++ b/open-terminal/caja-open-terminal.c
@@ -641,6 +641,7 @@ caja_open_terminal_register_type (GTypeModule *module)
 		sizeof (CajaOpenTerminal),
 		0,
 		(GInstanceInitFunc) caja_open_terminal_instance_init,
+		NULL
 	};
 
 	static const GInterfaceInfo menu_provider_iface_info = {

--- a/sendto/caja-nste.c
+++ b/sendto/caja-nste.c
@@ -143,6 +143,7 @@ caja_nste_register_type (GTypeModule *module)
 		sizeof (CajaNste),
 		0,
 		(GInstanceInitFunc) caja_nste_instance_init,
+		NULL
 	};
 
 	static const GInterfaceInfo menu_provider_iface_info = {

--- a/sendto/caja-sendto-command.c
+++ b/sendto/caja-sendto-command.c
@@ -80,7 +80,7 @@ struct _NS_ui {
 
 static const GOptionEntry entries[] = {
 	{ G_OPTION_REMAINING, '\0', 0, G_OPTION_ARG_FILENAME_ARRAY, &filenames, "Files to send", "[FILES...]" },
-	{ NULL }
+	{ NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL, NULL }
 };
 
 static void

--- a/share/caja-share.c
+++ b/share/caja-share.c
@@ -1206,6 +1206,7 @@ caja_share_register_type (GTypeModule *module)
     sizeof (CajaShare),
     0,
     (GInstanceInitFunc) caja_share_instance_init,
+    NULL
   };
 
   share_type = g_type_module_register_type (module,

--- a/wallpaper/caja-wallpaper-extension.c
+++ b/wallpaper/caja-wallpaper-extension.c
@@ -167,6 +167,7 @@ caja_cwe_register_type (GTypeModule *module)
         sizeof (CajaCwe),
         0,
         (GInstanceInitFunc) caja_cwe_instance_init,
+        NULL
     };
 
     static const GInterfaceInfo menu_provider_iface_info = {

--- a/xattr-tags/caja-xattr-tags-extension.c
+++ b/xattr-tags/caja-xattr-tags-extension.c
@@ -231,6 +231,7 @@ caja_xattr_tags_register_type(GTypeModule *module)
         sizeof (CajaXattrTags),
         0,
         (GInstanceInitFunc) caja_xattr_tags_instance_init,
+        NULL
     };
 
 


### PR DESCRIPTION
```
caja-open-terminal.c:644:2: warning: missing field 'value_table' initializer [-Wmissing-field-initializers]
        };
        ^
--
caja-sendto-command.c:83:9: warning: missing field 'short_name' initializer [-Wmissing-field-initializers]
        { NULL }
               ^
--
caja-nste.c:146:2: warning: missing field 'value_table' initializer [-Wmissing-field-initializers]
        };
        ^
--
caja-image-converter.c:185:2: warning: missing field 'value_table' initializer [-Wmissing-field-initializers]
        };
        ^
--
libcaja-gksu.c:63:5: warning: missing field 'value_table' initializer [-Wmissing-field-initializers]
    };
    ^
--
caja-share.c:1209:3: warning: missing field 'value_table' initializer [-Wmissing-field-initializers]
  };
  ^
--
caja-wallpaper-extension.c:170:5: warning: missing field 'value_table' initializer [-Wmissing-field-initializers]
    };
    ^
--
caja-xattr-tags-extension.c:234:5: warning: missing field 'value_table' initializer [-Wmissing-field-initializers]
    };
    ^
```