### PR TITLE
Fix build warning -Wmissing-prototypes

### DIFF
--- a/image-converter/image-converter.c
+++ b/image-converter/image-converter.c
@@ -27,6 +27,8 @@
 
 #include <glib/gi18n-lib.h>
 
+#include <libcaja-extension/caja-extension-types.h>
+
 #include "caja-image-converter.h"
 
 static GType type_list[1];

--- a/open-terminal/open-terminal.c
+++ b/open-terminal/open-terminal.c
@@ -27,6 +27,8 @@
 
 #include <glib/gi18n-lib.h>
 
+#include <libcaja-extension/caja-extension-types.h>
+
 #include "caja-open-terminal.h"
 
 static GType type_list[1];


### PR DESCRIPTION
```
open-terminal.c:35:1: warning: no previous prototype for function 'caja_module_initialize' [-Wmissing-prototypes]
caja_module_initialize (GTypeModule *module)
^
--
open-terminal.c:44:1: warning: no previous prototype for function 'caja_module_shutdown' [-Wmissing-prototypes]
caja_module_shutdown (void)
^
--
open-terminal.c:50:1: warning: no previous prototype for function 'caja_module_list_types' [-Wmissing-prototypes]
caja_module_list_types (const GType **types,
^
--
image-converter.c:35:1: warning: no previous prototype for function 'caja_module_initialize' [-Wmissing-prototypes]
caja_module_initialize (GTypeModule *module)
^
--
image-converter.c:44:1: warning: no previous prototype for function 'caja_module_shutdown' [-Wmissing-prototypes]
caja_module_shutdown (void)
^
--
image-converter.c:50:1: warning: no previous prototype for function 'caja_module_list_types' [-Wmissing-prototypes]
caja_module_list_types (const GType **types,
^
```