### PR TITLE
Fixed caja-share not working under Arch Linux

### DIFF
--- a/share/shares.c
+++ b/share/shares.c
@@ -622,7 +622,7 @@ add_share (ShareInfo *info, GError **error)
 		return FALSE;
 
 	argv[0] = "add";
-	argv[1] = "-l";
+	argv[1] = "--long";
 	argv[2] = info->share_name;
 	argv[3] = info->path;
 	argv[4] = info->comment;


### PR DESCRIPTION
Found a very minor syntax error with the share feature in Caja which prevented me from being able to start samba shares under Arch Linux. Literally changed one line and fixed the problem.