### PR TITLE
Fix missing GtkRadioButton id

### DIFF
--- a/image-converter/caja-image-resize.ui
+++ b/image-converter/caja-image-resize.ui
@@ -183,7 +183,7 @@
                             <property name="can_focus">False</property>
                             <property name="spacing">8</property>
                             <child>
-                              <object class="GtkRadioButton">
+                              <object class="GtkRadioButton" id="custom_pct_radiobutton">
                                 <property name="label" translatable="yes">Scale:</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>


### PR DESCRIPTION
Add missing id to custom scale radio button referenced in caja-image-resizer.c This fixes issue #104.