### PR TITLE
sendto: multiple small fixes

### DIFF
--- a/sendto/caja-sendto-command.c
+++ b/sendto/caja-sendto-command.c
@@ -185,8 +185,9 @@ pack_files (NS_ui *ui)
 	char *engrampa_cmd;
 	const char *filename;
 	GList *l;
-	GString *cmd, *tmp;
-	char *pack_type, *tmp_dir, *tmp_work_dir, *packed_file;
+	GString *cmd;
+	char *pack_type, *tmp_dir, *tmp_work_dir;
+	char *packed_file, *packed_file_esc, *packed_file_uri;
 
 	engrampa_cmd = g_find_program_in_path ("engrampa");
 	filename = gtk_entry_get_text(GTK_ENTRY(ui->pack_entry));
@@ -213,33 +214,36 @@ pack_files (NS_ui *ui)
 			    CAJA_SENDTO_LAST_COMPRESS,
 			    gtk_combo_box_get_active(GTK_COMBO_BOX(ui->pack_combobox)));
 
+	packed_file = g_strconcat (tmp_work_dir, "/", filename, pack_type, NULL);
+	g_free (pack_type);
+	g_free (tmp_work_dir);
+
 	cmd = g_string_new ("");
-	g_string_printf (cmd, "%s --add-to=\"%s/%s%s\"",
-			 engrampa_cmd, tmp_work_dir,
-			 filename,
-			 pack_type);
+	packed_file_esc = g_shell_quote (packed_file);
+	g_string_printf (cmd, "%s --add-to=%s", engrampa_cmd, packed_file_esc);
+	g_free (packed_file_esc);
 	g_free (engrampa_cmd);
 
 	/* engrampa doesn't understand URIs */
 	for (l = file_list ; l; l=l->next){
 		char *file;
+		char *file_esc;
 
 		file = g_filename_from_uri (l->data, NULL, NULL);
-		g_string_append_printf (cmd," \"%s\"", file);
+		file_esc = g_shell_quote (file);
+		g_string_append_printf (cmd," %s", file_esc);
+
+		g_free (file_esc);
 		g_free (file);
 	}
 
 	g_spawn_command_line_sync (cmd->str, NULL, NULL, NULL, NULL);
 	g_string_free (cmd, TRUE);
-	tmp = g_string_new("");
-	g_string_printf (tmp,"%s/%s%s", tmp_work_dir,
-			 filename,
-			 pack_type);
-	g_free (pack_type);
-	g_free (tmp_work_dir);
-	packed_file = g_filename_to_uri (tmp->str, NULL, NULL);
-	g_string_free(tmp, TRUE);
-	return packed_file;
+
+	packed_file_uri = g_filename_to_uri (packed_file, NULL, NULL);
+	g_free (packed_file);
+
+	return packed_file_uri;
 }
 
 static gboolean

--- a/sendto/caja-sendto-command.c
+++ b/sendto/caja-sendto-command.c
@@ -188,6 +188,7 @@ pack_files (NS_ui *ui)
 	GString *cmd;
 	char *pack_type, *tmp_dir, *tmp_work_dir;
 	char *packed_file, *packed_file_esc, *packed_file_uri;
+	GFile *fp;
 
 	engrampa_cmd = g_find_program_in_path ("engrampa");
 	filename = gtk_entry_get_text(GTK_ENTRY(ui->pack_entry));
@@ -242,6 +243,15 @@ pack_files (NS_ui *ui)
 
 	packed_file_uri = g_filename_to_uri (packed_file, NULL, NULL);
 	g_free (packed_file);
+
+	if (packed_file_uri != NULL) {
+		fp = g_file_new_for_uri (packed_file_uri);
+		if (!g_file_query_exists (fp, NULL)) {
+			g_free (packed_file_uri);
+			packed_file_uri = NULL;
+		}
+		g_object_unref (fp);
+	}
 
 	return packed_file_uri;
 }

--- a/sendto/plugins/emailclient/emailclient.c
+++ b/sendto/plugins/emailclient/emailclient.c
@@ -48,23 +48,8 @@ static MailerType type = MAILER_UNKNOWN;
 static char *
 get_evo_cmd (void)
 {
-	char *tmp = NULL;
-	char *retval;
-	char *cmds[] = {"evolution",
-		"evolution-2.0",
-		"evolution-2.2",
-		"evolution-2.4",
-		"evolution-2.6",
-		"evolution-2.8", /* for the future */
-		"evolution-3.0", /* but how far to go ? */
-		NULL};
-	guint i;
-
-	for (i = 0; cmds[i] != NULL; i++) {
-		tmp = g_find_program_in_path (cmds[i]);
-		if (tmp != NULL)
-			break;
-	}
+	char *tmp, *retval;
+	tmp = g_find_program_in_path ("evolution");
 
 	if (tmp == NULL)
 		return NULL;

--- a/sendto/plugins/removable-devices/removable-devices.c
+++ b/sendto/plugins/removable-devices/removable-devices.c
@@ -216,6 +216,24 @@ get_contacts_widget (NstPlugin *plugin)
 	return cb;
 }
 
+static void
+show_error (const gchar *title, const gchar *message)
+{
+	GtkWidget *dialog;
+
+	dialog = gtk_message_dialog_new_with_markup(NULL,
+								GTK_DIALOG_DESTROY_WITH_PARENT,
+								GTK_MESSAGE_ERROR,
+								GTK_BUTTONS_CLOSE, NULL);
+
+	gchar *msg = g_markup_printf_escaped("<b>%s</b>\n\n%s", title, message);
+	gtk_message_dialog_set_markup (GTK_MESSAGE_DIALOG (dialog), msg);
+	g_free (msg);
+
+	gtk_dialog_run (GTK_DIALOG (dialog));
+	gtk_widget_destroy (dialog);
+}
+
 static gboolean
 send_files (NstPlugin *plugin, GtkWidget *contact_widget,
 	    GList *file_list)
@@ -224,6 +242,7 @@ send_files (NstPlugin *plugin, GtkWidget *contact_widget,
 	GtkTreeIter iter;
 	GMount *dest_mount;
 	GFile *mount_root;
+	gboolean ret;
 
 	if (gtk_combo_box_get_active_iter (GTK_COMBO_BOX (contact_widget), &iter) == FALSE)
 		return TRUE;
@@ -232,11 +251,14 @@ send_files (NstPlugin *plugin, GtkWidget *contact_widget,
 	gtk_tree_model_get (GTK_TREE_MODEL (store), &iter, MOUNT_COL, &dest_mount, -1);
 	mount_root = g_mount_get_root (dest_mount);
 
-	copy_files_to (file_list, mount_root);
+	ret = copy_files_to (file_list, mount_root);
+	if (ret == FALSE)
+		show_error(_("Failed"),
+			_("One or more files failed to copy."));
 
 	g_object_unref (mount_root);
 
-	return TRUE;
+	return ret;
 }
 
 static gboolean


### PR DESCRIPTION
Multiple fixes or changes in Sendto:

### pack
- Fix: Handle quote in filename (= escape `'` ).

- Check pack was created.
(( Example to reproduce the problem: pack will fail with an invalid pack filename (e.g. character `/` ) )

- ~~Fix: update outdated schema description & there sync there translation.~~
 I've removed this commit from here, because of lots of simultaneous changes in all translation files ;
 (( Maybe I will resubmit it, but separated. ))
The outdated string:
_Used to store which type of archive was used the last time (0: zip, 1: tar.gz, 2: tar.bz2)._
Should be string:
_Used to store which type of archive was used the last time (0: 7z, 1: tar.bz2, 2: tar.gz, 3: tar.xz, 4: zip)._
In file: org.mate.Caja.Sendto.gschema.xml.in
(( Reference: options in [caja-sendto.ui at line 230](https://github.com/mate-desktop/caja-extensions/blob/master/sendto/caja-sendto.ui#L230) ))

### removeable devices:
 - Fix: New error dialog added.
(( The function  `show_error`  is copied 1:1 from plugin [gajim.c](https://github.com/mate-desktop/caja-extensions/blob/master/sendto/plugins/gajim/gajim.c#L389) ))
(( Example to reproduce the problem: File already exists or filename on target filesystem not allowed (e.g. character `:` on USB flash drive with file-system format FAT32 ) ))

### emailplugin:
- Remove support for code for ancient evolution version.
(( backported from [nautilus](https://gitlab.gnome.org/Archive/nautilus-sendto/-/commit/aa74153c5b9fd448e40dffa895f63b23fa96b5f0) ))